### PR TITLE
Fix #65

### DIFF
--- a/numpy/distutils/ccompiler.py
+++ b/numpy/distutils/ccompiler.py
@@ -491,6 +491,8 @@ def CCompiler_customize_set_compiler(self):
         if not hasattr(self, 'compiler_cxx'):
             log.warn('Missing compiler_cxx fix for ' + self.__class__.__name__)
 
+replace_method(CCompiler, 'customize_set_compiler', CCompiler_customize_set_compiler)
+
 def CCompiler_customize(self, dist, need_cxx=0):
     """
     Do any platform-specific customization of a compiler instance.


### PR DESCRIPTION
Fixed bug with replace_method not being called for the new method CCompiler_customize_set_compiler in ccompiler.py in the refactoring. Fix #65.

<!-- Please be sure you are following the instructions in the dev guidelines
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html
-->

<!-- We'd appreciate it if your commit message is properly formatted
http://www.numpy.org/devdocs/dev/gitwash/development_workflow.html#writing-the-commit-message
-->
